### PR TITLE
Fix pi-mem.conf typo: correct "arm" to "gpu"

### DIFF
--- a/telegraf.d/044-pi-mem.conf
+++ b/telegraf.d/044-pi-mem.conf
@@ -9,7 +9,7 @@
   commands = [ "sudo vcgencmd get_mem gpu" ]
   name_override = "rpi_mem"
   data_format = "grok"
-  grok_patterns = ["%{NUMBER:arm:int}"]
+  grok_patterns = ["%{NUMBER:gpu:int}"]
 [[inputs.exec]] 
   commands = [ "sudo vcgencmd get_mem malloc" ]
   name_override = "rpi_mem"


### PR DESCRIPTION
I'm not familiar with the grok format/pattern, but having both `vcgencmd get_mem arm` and `vcgencmd get_mem gpu` writing to the "arm" field doesn't seem correct, and resulted in the GPU data being unavailable in InfluxDB.

I suspect this was just a simple copy/paste oversight :)

Thanks for this repo/config, btw! It saved me a fair bit of time setting up Telegraf across all my RPis 😸 

_Edit: GitHub's editor automatically inserted that end-of-file newline and I didn't spot it until it had been committed and I was in the middle of the PR wizard, sorry 🙄 I wouldn't have committed an irrelevant newline if this change had gone through my usual desktop apps!_